### PR TITLE
fix: prevent emoji picker "Illegal constructor" crash on plugin reload

### DIFF
--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -1,7 +1,9 @@
 import data from '@emoji-mart/data';
-import Picker from '@emoji-mart/react';
+import { Picker } from 'emoji-mart';
 import type React from 'react';
+import { useEffect, useRef } from 'react';
 import type { EmojiData } from '../types';
+import { resolveEmojiPickerConstructor } from './emoji-picker-element';
 
 interface EmojiPickerProps {
 	onEmojiSelect: (emoji: EmojiData) => void;
@@ -9,32 +11,59 @@ interface EmojiPickerProps {
 }
 
 export const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect, theme = 'light' }) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	// Keep the latest callback without rebuilding the picker on every render.
+	const onEmojiSelectRef = useRef(onEmojiSelect);
+	useEffect(() => {
+		onEmojiSelectRef.current = onEmojiSelect;
+	});
+
+	useEffect(() => {
+		const parent = containerRef.current;
+		if (!parent) {
+			return;
+		}
+
+		// Instantiate the constructor that is actually registered for
+		// <em-emoji-picker> rather than the freshly bundled `Picker` class.
+		// See resolveEmojiPickerConstructor for why this avoids the
+		// "Illegal constructor" crash after a plugin reload (issue #4).
+		const PickerConstructor = resolveEmojiPickerConstructor(
+			Picker as unknown as CustomElementConstructor
+		);
+
+		const instance = new PickerConstructor({
+			data,
+			theme,
+			onEmojiSelect: (emoji: EmojiData) => onEmojiSelectRef.current(emoji),
+			set: 'native',
+			previewPosition: 'none',
+			skinTonePosition: 'none',
+			searchPosition: 'top',
+			emojiSize: 20,
+			perLine: 8,
+			maxFrequentRows: 0,
+			locale: 'ko',
+			categories: [
+				'frequent',
+				'people',
+				'nature',
+				'foods',
+				'activity',
+				'places',
+				'objects',
+				'symbols',
+				'flags',
+			],
+			parent,
+		});
+
+		return () => {
+			instance.remove();
+		};
+	}, [theme]);
+
 	return (
-		<div className="obsidian-context-workspaces-emoji-picker-wrapper">
-			<Picker
-				data={data}
-				theme={theme}
-				onEmojiSelect={onEmojiSelect}
-				set="native"
-				previewPosition="none"
-				skinTonePosition="none"
-				searchPosition="top"
-				emojiSize={20}
-				perLine={8}
-				maxFrequentRows={0}
-				locale="ko"
-				categories={[
-					'frequent',
-					'people',
-					'nature',
-					'foods',
-					'activity',
-					'places',
-					'objects',
-					'symbols',
-					'flags',
-				]}
-			/>
-		</div>
+		<div ref={containerRef} className="obsidian-context-workspaces-emoji-picker-wrapper" />
 	);
 };

--- a/src/components/emoji-picker-element.ts
+++ b/src/components/emoji-picker-element.ts
@@ -1,0 +1,29 @@
+/**
+ * Tag name emoji-mart registers its picker web component under.
+ */
+export const EMOJI_PICKER_TAG = 'em-emoji-picker';
+
+/**
+ * Resolve the custom-element constructor that should be instantiated for the
+ * emoji picker.
+ *
+ * emoji-mart registers `<em-emoji-picker>` via `customElements.define()` exactly
+ * once per page (guarded by `!customElements.get()`). Obsidian never reloads the
+ * renderer window when a plugin is toggled or updated, so that registration
+ * survives across plugin reloads. After a reload the freshly bundled `Picker`
+ * class is a *different* object than the one in the registry, and calling
+ * `new FreshPicker()` throws:
+ *
+ *     TypeError: Failed to construct 'HTMLElement': Illegal constructor
+ *
+ * because, per the custom elements spec, `new` is only valid on the constructor
+ * that is actually registered. This caused the blank screen reported in issue
+ * #4. Always instantiate the constructor that lives in the registry, falling
+ * back to the freshly bundled class on the very first load (before the
+ * registration side effect has run for this page).
+ */
+export function resolveEmojiPickerConstructor(
+	fallback: CustomElementConstructor
+): CustomElementConstructor {
+	return customElements.get(EMOJI_PICKER_TAG) ?? fallback;
+}

--- a/tests/emoji-picker.test.ts
+++ b/tests/emoji-picker.test.ts
@@ -1,0 +1,51 @@
+import {
+	EMOJI_PICKER_TAG,
+	resolveEmojiPickerConstructor,
+} from '../src/components/emoji-picker-element';
+
+/**
+ * Regression tests for issue #4: changing the icon produced a blank screen with
+ * "Failed to construct 'HTMLElement': Illegal constructor".
+ *
+ * Tests run in declaration order. The first test must run while the tag is
+ * still unregistered, so do not import emoji-mart (or EmojiPicker) in this file.
+ */
+describe('resolveEmojiPickerConstructor (issue #4)', () => {
+	it('returns the fallback before the picker tag is registered (first load)', () => {
+		class FreshPicker extends HTMLElement {}
+
+		expect(customElements.get(EMOJI_PICKER_TAG)).toBeUndefined();
+		expect(resolveEmojiPickerConstructor(FreshPicker)).toBe(FreshPicker);
+	});
+
+	it('resolves to the registered constructor, not a stale bundled class (reload)', () => {
+		// A previous plugin load registered the tag with this class.
+		class RegisteredPicker extends HTMLElement {
+			constructor(_props?: unknown) {
+				super();
+			}
+		}
+		// A fresh plugin load produces a brand new class. Obsidian keeps the
+		// renderer page alive, so define() is skipped and this class is NOT in
+		// the registry.
+		class StalePicker extends HTMLElement {}
+
+		customElements.define(EMOJI_PICKER_TAG, RegisteredPicker);
+
+		// Reproduce the crash: constructing the unregistered class throws. Chromium
+		// (Obsidian) reports "Illegal constructor"; jsdom reports "not part of the
+		// custom element registry" — same root cause, different wording.
+		expect(() => new StalePicker()).toThrow(
+			/Illegal constructor|not part of the custom element registry/
+		);
+
+		// The fix picks the registered constructor instead of the stale one...
+		const Ctor = resolveEmojiPickerConstructor(
+			StalePicker as unknown as CustomElementConstructor
+		);
+		expect(Ctor).toBe(RegisteredPicker);
+
+		// ...and constructing it no longer throws.
+		expect(() => new Ctor()).not.toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #4 — clicking the emoji to change a space icon showed a **blank screen** with:

```
TypeError: Failed to construct 'HTMLElement': Illegal constructor
```

## Root cause

`@emoji-mart/react` instantiates the picker via `new Picker()`. emoji-mart registers the `<em-emoji-picker>` web component with `customElements.define()` **only once per page** (guarded by `!customElements.get()`).

**Obsidian never reloads the renderer window when a plugin is toggled or updated**, so that registration survives across plugin reloads. After a reload, the freshly bundled `Picker` class is a *different object* than the one in the registry, and the Custom Elements spec forbids `new` on an unregistered constructor → crash.

This is why it works on a fresh install but breaks after any reload/update (so it was easy to miss in testing).

## Fix

Instantiate the constructor that is **actually in the registry** (`customElements.get('em-emoji-picker')`) instead of the freshly bundled class, falling back to the bundled class on first load. The `@emoji-mart/react` wrapper is replaced with a direct vanilla mount in `EmojiPicker`.

- `src/components/emoji-picker-element.ts` (new) — `resolveEmojiPickerConstructor()` helper
- `src/components/EmojiPicker.tsx` — vanilla mount via the resolved constructor; latest-callback ref pattern
- `tests/emoji-picker.test.ts` (new) — regression tests reproducing the stale-registry scenario

## Verification

- ✅ `tsc -noEmit -skipLibCheck`
- ✅ eslint
- ✅ 130 tests pass (incl. 2 new regression tests)
- ✅ production build; bundle retains both `define` and `get` for the tag

## Notes

- No version bump here — release will be cut once the other issue fixes (#3/#5/#7) are merged too.
- `@emoji-mart/react` is now unused; can be dropped from `package.json` in a follow-up.
- Recommend a manual check in Obsidian: change an icon → reload the plugin → change an icon again.

Closes #4