### PR TITLE
feat: add settings button to the sidebar view header

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -435,6 +435,20 @@ export default class ContextWorkspacesPlugin extends Plugin {
 		new SpaceManagerModal(this.app, this).open();
 	}
 
+	/**
+	 * Open this plugin's settings tab.
+	 * `app.setting` is an internal (undocumented) Obsidian API.
+	 */
+	openSettings(): void {
+		const setting = (
+			this.app as unknown as {
+				setting?: { open: () => void; openTabById: (id: string) => void };
+			}
+		).setting;
+		setting?.open();
+		setting?.openTabById(this.manifest.id);
+	}
+
 
 
 	async deleteSpace(spaceId: string) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -125,6 +125,7 @@ export interface ContextWorkspacesPlugin {
 	switchToSpace(spaceId: string, method?: string): Promise<void>;
 	createNewSpace(): Promise<void>;
 	openSpaceManager(): void;
+	openSettings(): void;
 	deleteSpace(spaceId: string): Promise<void>;
 	updateSidebarSpaces(): void;
 	updateSidebarSpacesOptimized(): void;

--- a/src/views/ContextWorkspacesView.ts
+++ b/src/views/ContextWorkspacesView.ts
@@ -13,6 +13,7 @@ export const VIEW_TYPE_CONTEXT_WORKSPACES = 'context-workspaces-view';
 export class ContextWorkspacesView extends ItemView {
 	plugin: ContextWorkspacesPlugin;
 	private reactWrapper: ReactWrapper;
+	private settingsActionAdded = false;
 
 	constructor(leaf: WorkspaceLeaf, plugin: ContextWorkspacesPlugin) {
 		super(leaf);
@@ -33,6 +34,13 @@ export class ContextWorkspacesView extends ItemView {
 	}
 
 	async onOpen(): Promise<void> {
+		// Add a gear button to the view header that opens the plugin settings.
+		// Guarded so reopening the view does not stack duplicate actions.
+		if (!this.settingsActionAdded) {
+			this.addAction('settings', 'Open settings', () => this.plugin.openSettings());
+			this.settingsActionAdded = true;
+		}
+
 		const container = this.containerEl.children[1];
 		if (container.instanceOf(HTMLElement)) {
 			container.empty();


### PR DESCRIPTION
## Summary

Implements #5 — adds a **gear button to the Context Workspaces sidebar view header** that opens the plugin settings directly.

## Changes

- `src/views/ContextWorkspacesView.ts` — `addAction('settings', 'Open settings', …)` in `onOpen()`, guarded with a flag so reopening the view doesn't stack duplicate buttons.
- `src/main.ts` — new `openSettings()` that calls `app.setting.open()` and `openTabById(manifest.id)` to jump straight to this plugin's tab (`app.setting` is an internal API, cast through `unknown`).
- `src/types/index.ts` — `openSettings()` added to the `ContextWorkspacesPlugin` interface.

## Verification

- ✅ `tsc -noEmit -skipLibCheck`, eslint, production build
- ✅ 128 tests pass (pre-commit)
- Manual check recommended: open the sidebar → click the gear icon in the header → plugin settings open.

## Notes

- No version bump — release will bundle this with the other issue fixes (#3/#4/#7).

Closes #5