### PR TITLE
feat: add "Activate on startup" setting for the sidebar tab

### DIFF
--- a/src/components/ContextWorkspacesSettingTab.tsx
+++ b/src/components/ContextWorkspacesSettingTab.tsx
@@ -141,6 +141,9 @@ export const ContextWorkspacesSettingTab: React.FC<ContextWorkspacesSettingTabPr
 	const [spaceOrder, setSpaceOrder] = useState(plugin.settings.spaceOrder);
 	const [showHelp, setShowHelp] = useState(false);
 	const [editingSpaceId, setEditingSpaceId] = useState<string | null>(null);
+	const [activateOnStartup, setActivateOnStartup] = useState(
+		plugin.settings.activateViewOnStartup !== false
+	);
 
 	// Update state when plugin settings change
 	useEffect(() => {
@@ -202,6 +205,13 @@ export const ContextWorkspacesSettingTab: React.FC<ContextWorkspacesSettingTabPr
 		setSpaces(updatedSpaces);
 
 		plugin.updateSidebarSpacesOptimized();
+	};
+
+	const handleToggleActivateOnStartup = () => {
+		const next = !activateOnStartup;
+		setActivateOnStartup(next);
+		plugin.settings.activateViewOnStartup = next;
+		void plugin.saveSettings();
 	};
 
 	const handleEditSpace = (spaceId: string) => {
@@ -298,6 +308,32 @@ export const ContextWorkspacesSettingTab: React.FC<ContextWorkspacesSettingTabPr
 				</div>
 
 				<h3>General settings</h3>
+
+				<div className="obsidian-context-workspaces-setting-item">
+					<div className="obsidian-context-workspaces-setting-item-info">
+						<div className="obsidian-context-workspaces-setting-item-name">
+							Activate on startup
+						</div>
+						<div className="obsidian-context-workspaces-setting-item-description">
+							Open the Context Workspaces tab and bring it to the front when Obsidian
+							starts. Disable to keep your last-used sidebar tab in front.
+						</div>
+					</div>
+					<div className="obsidian-context-workspaces-setting-item-control">
+						<button
+							type="button"
+							className={`obsidian-context-workspaces-switch-toggle ${activateOnStartup ? 'active' : ''}`}
+							onClick={handleToggleActivateOnStartup}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									handleToggleActivateOnStartup();
+								}
+							}}
+							aria-label="Toggle activate Context Workspaces on startup"
+						/>
+					</div>
+				</div>
 
 				<div className="obsidian-context-workspaces-setting-item">
 					<div className="obsidian-context-workspaces-setting-item-info">

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,9 +48,13 @@ export default class ContextWorkspacesPlugin extends Plugin {
 			return new ContextWorkspacesView(leaf, this);
 		});
 
-		// Activate view when layout is ready
+		// Activate view when layout is ready, unless the user opted out so their
+		// last-used sidebar tab stays in front. The view leaf is still restored
+		// by Obsidian's saved layout; it just isn't forced to the foreground.
 		this.app.workspace.onLayoutReady(() => {
-			void this.activateView();
+			if (this.settings.activateViewOnStartup !== false) {
+				void this.activateView();
+			}
 		});
 
 		// Add ribbon icon for quick toggle

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,7 @@ export interface ContextWorkspacesSettings {
 	currentSpaceId: string;
 	workspaceLastSeen?: Record<string, number>; // Track when workspaces were last seen
 	sidebarViewMode?: SidebarViewMode; // Sidebar display mode: 'icon' or 'list'
+	activateViewOnStartup?: boolean; // Reveal the Context Workspaces tab on startup
 }
 
 export const DEFAULT_SETTINGS: ContextWorkspacesSettings = {
@@ -116,6 +117,7 @@ export const DEFAULT_SETTINGS: ContextWorkspacesSettings = {
 	currentSpaceId: '',
 	spaceOrder: [],
 	sidebarViewMode: 'icon',
+	activateViewOnStartup: true,
 };
 
 export interface ContextWorkspacesPlugin {


### PR DESCRIPTION
## Summary

Implements #7 — the Context Workspaces sidebar tab was **always revealed and brought to the front on startup**, overriding the user's last-used sidebar tab. This adds a setting to opt out.

## Behavior

- **Setting: "Activate on startup"** (General settings), default **on** → preserves current behavior for existing users.
- When **off**, the startup `revealLeaf` is skipped. The view leaf is still restored by Obsidian's saved layout and remains reachable via the ribbon icon and the commands — it just isn't forced to the foreground.

## Changes

- `src/types/index.ts` — `activateViewOnStartup?: boolean` + `DEFAULT_SETTINGS` default `true`.
- `src/main.ts` — `onLayoutReady` activation guarded by `this.settings.activateViewOnStartup !== false` (treats undefined as on).
- `src/components/ContextWorkspacesSettingTab.tsx` — toggle in General settings.

## Verification

- ✅ `tsc -noEmit -skipLibCheck`, eslint, production build
- ✅ 128 tests pass (pre-commit)
- Manual check: toggle off → restart Obsidian → your previous sidebar tab stays in front; the Context Workspaces tab is still present.

## Notes

- No version bump — release will bundle this with the other issue fixes (#3/#4/#5).
- Touches the same settings files as #3; expect a trivial merge conflict in `DEFAULT_SETTINGS` / the settings tab when both land.

Closes #7