### PR TITLE
feat: add status bar space switcher

### DIFF
--- a/src/components/ContextWorkspacesSettingTab.tsx
+++ b/src/components/ContextWorkspacesSettingTab.tsx
@@ -141,6 +141,7 @@ export const ContextWorkspacesSettingTab: React.FC<ContextWorkspacesSettingTabPr
 	const [spaceOrder, setSpaceOrder] = useState(plugin.settings.spaceOrder);
 	const [showHelp, setShowHelp] = useState(false);
 	const [editingSpaceId, setEditingSpaceId] = useState<string | null>(null);
+	const [showStatusBar, setShowStatusBar] = useState(plugin.settings.showStatusBar !== false);
 
 	// Update state when plugin settings change
 	useEffect(() => {
@@ -202,6 +203,14 @@ export const ContextWorkspacesSettingTab: React.FC<ContextWorkspacesSettingTabPr
 		setSpaces(updatedSpaces);
 
 		plugin.updateSidebarSpacesOptimized();
+	};
+
+	const handleToggleStatusBar = () => {
+		const next = !showStatusBar;
+		setShowStatusBar(next);
+		plugin.settings.showStatusBar = next;
+		void plugin.saveSettings();
+		plugin.refreshStatusBar();
 	};
 
 	const handleEditSpace = (spaceId: string) => {
@@ -298,6 +307,32 @@ export const ContextWorkspacesSettingTab: React.FC<ContextWorkspacesSettingTabPr
 				</div>
 
 				<h3>General settings</h3>
+
+				<div className="obsidian-context-workspaces-setting-item">
+					<div className="obsidian-context-workspaces-setting-item-info">
+						<div className="obsidian-context-workspaces-setting-item-name">
+							Show status bar switcher
+						</div>
+						<div className="obsidian-context-workspaces-setting-item-description">
+							Show the current space in the status bar. Click it to quickly switch
+							between spaces.
+						</div>
+					</div>
+					<div className="obsidian-context-workspaces-setting-item-control">
+						<button
+							type="button"
+							className={`obsidian-context-workspaces-switch-toggle ${showStatusBar ? 'active' : ''}`}
+							onClick={handleToggleStatusBar}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' || e.key === ' ') {
+									e.preventDefault();
+									handleToggleStatusBar();
+								}
+							}}
+							aria-label="Toggle status bar space switcher"
+						/>
+					</div>
+				</div>
 
 				<div className="obsidian-context-workspaces-setting-item">
 					<div className="obsidian-context-workspaces-setting-item-info">

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, type TFile } from 'obsidian';
+import { Menu, Notice, Plugin, type TFile } from 'obsidian';
 import type { ContextWorkspacesSettings } from './types';
 import { DEFAULT_SETTINGS } from './types';
 import { needsDeletionDetection, safeDeletionDetection } from './utils/deletion-detection-utils';
@@ -23,6 +23,7 @@ import {
 	parseSpaceData,
 	searchSpaces,
 } from './utils/space-utils';
+import { formatStatusBarLabel } from './utils/status-bar-utils';
 import { needsSync, safeBidirectionalSync } from './utils/sync-utils';
 import {
 	ContextWorkspacesView,
@@ -39,6 +40,7 @@ export default class ContextWorkspacesPlugin extends Plugin {
 	layoutChangeTimeout: number;
 	workspaceChangeTimeout: number;
 	switchingToSpaceId: string | null = null;
+	private statusBarItem: HTMLElement | null = null;
 
 	async onload() {
 		await this.loadSettings();
@@ -122,6 +124,9 @@ export default class ContextWorkspacesPlugin extends Plugin {
 		// Initialize default space
 		await this.initializeDefaultSpace();
 
+		// Set up the status bar space switcher
+		this.setupStatusBar();
+
 		// Initialize workspace synchronization
 		await this.initializeWorkspaceSync();
 
@@ -157,6 +162,9 @@ export default class ContextWorkspacesPlugin extends Plugin {
 		// Clear timeouts
 		window.clearTimeout(this.layoutChangeTimeout);
 		window.clearTimeout(this.workspaceChangeTimeout);
+
+		// Drop the status bar reference (Obsidian removes the element itself)
+		this.statusBarItem = null;
 
 		// Remove workspace load monitoring
 		removeWorkspaceLoadMonitoring(this.app);
@@ -197,6 +205,78 @@ export default class ContextWorkspacesPlugin extends Plugin {
 			return leaves[0].view as ContextWorkspacesView;
 		}
 		return null;
+	}
+
+	/**
+	 * Create the status bar space switcher, if enabled.
+	 */
+	private setupStatusBar(): void {
+		if (this.settings.showStatusBar === false) {
+			return;
+		}
+
+		this.statusBarItem = this.addStatusBarItem();
+		this.statusBarItem.addClass('mod-clickable');
+		this.statusBarItem.setAttribute('aria-label', 'Switch space');
+		this.registerDomEvent(this.statusBarItem, 'click', (evt) => {
+			this.openStatusBarMenu(evt);
+		});
+
+		this.updateStatusBar();
+	}
+
+	/**
+	 * Update the status bar label to reflect the current space.
+	 */
+	private updateStatusBar(): void {
+		if (!this.statusBarItem) {
+			return;
+		}
+
+		const space = this.settings.spaces[this.settings.currentSpaceId];
+		this.statusBarItem.setText(space ? formatStatusBarLabel(space) : 'No space');
+	}
+
+	/**
+	 * Create or remove the status bar item to match the current setting.
+	 * Lets the settings toggle take effect without reloading the plugin.
+	 */
+	refreshStatusBar(): void {
+		if (this.settings.showStatusBar === false) {
+			this.statusBarItem?.remove();
+			this.statusBarItem = null;
+			return;
+		}
+
+		if (!this.statusBarItem) {
+			this.setupStatusBar();
+		} else {
+			this.updateStatusBar();
+		}
+	}
+
+	/**
+	 * Open a menu listing all spaces for quick switching.
+	 */
+	private openStatusBarMenu(evt: MouseEvent): void {
+		const menu = new Menu();
+
+		for (const spaceId of this.settings.spaceOrder) {
+			const space = this.settings.spaces[spaceId];
+			if (!space) {
+				continue;
+			}
+
+			menu.addItem((item) => {
+				item.setTitle(formatStatusBarLabel(space))
+					.setChecked(spaceId === this.settings.currentSpaceId)
+					.onClick(() => {
+						void this.switchToSpace(spaceId, 'status-bar');
+					});
+			});
+		}
+
+		menu.showAtMouseEvent(evt);
 	}
 
 	async loadSettings() {
@@ -260,6 +340,9 @@ export default class ContextWorkspacesPlugin extends Plugin {
 			// Switch to new space
 			this.settings.currentSpaceId = spaceId;
 			await this.saveSettings();
+
+			// Reflect the new current space in the status bar
+			this.updateStatusBar();
 
 			// Apply space theme if configured (with error handling)
 			const space = this.settings.spaces[spaceId];
@@ -504,6 +587,7 @@ export default class ContextWorkspacesPlugin extends Plugin {
 		window.setTimeout(() => {
 			try {
 				this.getView()?.render();
+				this.updateStatusBar();
 			} catch (error) {
 				console.error('Failed to update sidebar spaces:', error);
 			}
@@ -514,6 +598,7 @@ export default class ContextWorkspacesPlugin extends Plugin {
 		window.setTimeout(() => {
 			try {
 				this.getView()?.render();
+				this.updateStatusBar();
 			} catch (error) {
 				console.error('Failed to update sidebar spaces optimized:', error);
 			}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,7 @@ export interface ContextWorkspacesSettings {
 	currentSpaceId: string;
 	workspaceLastSeen?: Record<string, number>; // Track when workspaces were last seen
 	sidebarViewMode?: SidebarViewMode; // Sidebar display mode: 'icon' or 'list'
+	showStatusBar?: boolean; // Show the status bar space switcher
 }
 
 export const DEFAULT_SETTINGS: ContextWorkspacesSettings = {
@@ -116,6 +117,7 @@ export const DEFAULT_SETTINGS: ContextWorkspacesSettings = {
 	currentSpaceId: '',
 	spaceOrder: [],
 	sidebarViewMode: 'icon',
+	showStatusBar: true,
 };
 
 export interface ContextWorkspacesPlugin {
@@ -125,6 +127,7 @@ export interface ContextWorkspacesPlugin {
 	switchToSpace(spaceId: string, method?: string): Promise<void>;
 	createNewSpace(): Promise<void>;
 	openSpaceManager(): void;
+	refreshStatusBar(): void;
 	deleteSpace(spaceId: string): Promise<void>;
 	updateSidebarSpaces(): void;
 	updateSidebarSpacesOptimized(): void;

--- a/src/utils/status-bar-utils.ts
+++ b/src/utils/status-bar-utils.ts
@@ -1,0 +1,12 @@
+import type { SpaceConfig } from '../types';
+
+/** Fallback icon used when a space has no icon set. */
+export const DEFAULT_SPACE_ICON = '📄';
+
+/**
+ * Format the label shown in the status bar item and the space-switcher menu.
+ */
+export function formatStatusBarLabel(space: Pick<SpaceConfig, 'icon' | 'name'>): string {
+	const icon = space.icon || DEFAULT_SPACE_ICON;
+	return `${icon} ${space.name}`.trim();
+}

--- a/tests/status-bar-utils.test.ts
+++ b/tests/status-bar-utils.test.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_SPACE_ICON, formatStatusBarLabel } from '../src/utils/status-bar-utils';
+
+describe('formatStatusBarLabel', () => {
+	it('combines the space icon and name', () => {
+		expect(formatStatusBarLabel({ icon: '🏠', name: 'My Space' })).toBe('🏠 My Space');
+	});
+
+	it('falls back to the default icon when none is set', () => {
+		expect(formatStatusBarLabel({ icon: '', name: 'Work' })).toBe(
+			`${DEFAULT_SPACE_ICON} Work`
+		);
+	});
+
+	it('does not leave a trailing space when the name is empty', () => {
+		expect(formatStatusBarLabel({ icon: '🚀', name: '' })).toBe('🚀');
+	});
+});


### PR DESCRIPTION
## Summary

Implements #3 — adds a **status bar item** (like the [Workspaces Plus](https://github.com/jsmorabito/obsidian-workspaces-plus) plugin) showing the current space. Clicking it opens a menu of all spaces to switch between them.

## Behavior

- Status bar shows the current space as `<icon> <name>` (e.g. `🏠 My Space`).
- Click → a `Menu` lists every space (in `spaceOrder`); the current one is checked. Selecting one calls `switchToSpace(id, 'status-bar')`.
- Label stays in sync on space switch and after edits (rename / icon change) / sync.
- **Setting: "Show status bar switcher"** (default **on**) toggles it live — no reload needed.

## Changes

- `src/utils/status-bar-utils.ts` (new) — `formatStatusBarLabel()` pure helper.
- `src/main.ts` — `setupStatusBar` / `updateStatusBar` / `openStatusBarMenu` / `refreshStatusBar`; status bar refreshed from `switchToSpace` and the sidebar update helpers; reference dropped in `onunload`.
- `src/types/index.ts` — `showStatusBar?: boolean` (default `true`) + `refreshStatusBar()` on the plugin interface.
- `src/components/ContextWorkspacesSettingTab.tsx` — toggle in General settings.
- `tests/status-bar-utils.test.ts` (new) — label formatting tests.

## Verification

- ✅ `tsc -noEmit -skipLibCheck`, eslint, production build
- ✅ 131 tests pass (incl. 3 new)
- Manual check: status bar shows the current space → click → menu switches spaces → toggle setting hides/shows it instantly.

## Notes

- No version bump — release will bundle this with the other issue fixes (#4/#5/#7).
- Touches the same settings files as #7; expect a trivial merge conflict in `DEFAULT_SETTINGS` / the settings tab when both land.

Closes #3