### PR TITLE
fix: make the settings button visible in the sidebar (#5)

### DIFF
--- a/src/components/SidebarManager.tsx
+++ b/src/components/SidebarManager.tsx
@@ -353,6 +353,11 @@ export const SidebarManager: React.FC<SidebarManagerProps> = ({ plugin }) => {
 		void plugin.createNewSpace();
 	};
 
+	const handleOpenSettings = () => {
+		if (!isMountedRef.current) return;
+		plugin.openSettings();
+	};
+
 	const handleToggleViewMode = () => {
 		if (!isMountedRef.current) return;
 		const newMode: SidebarViewMode = viewMode === 'icon' ? 'list' : 'icon';
@@ -416,6 +421,17 @@ export const SidebarManager: React.FC<SidebarManagerProps> = ({ plugin }) => {
 							title={viewMode === 'icon' ? 'Switch to list view' : 'Switch to icon view'}
 						>
 							{viewMode === 'icon' ? '≡' : '⊞'}
+						</button>
+
+						{/* Settings button */}
+						<button
+							type="button"
+							className="obsidian-context-workspaces-settings-btn"
+							onClick={handleOpenSettings}
+							title="Open settings"
+							aria-label="Open settings"
+						>
+							{'⚙︎'}
 						</button>
 
 						{/* Help button */}

--- a/src/views/ContextWorkspacesView.ts
+++ b/src/views/ContextWorkspacesView.ts
@@ -13,7 +13,6 @@ export const VIEW_TYPE_CONTEXT_WORKSPACES = 'context-workspaces-view';
 export class ContextWorkspacesView extends ItemView {
 	plugin: ContextWorkspacesPlugin;
 	private reactWrapper: ReactWrapper;
-	private settingsActionAdded = false;
 
 	constructor(leaf: WorkspaceLeaf, plugin: ContextWorkspacesPlugin) {
 		super(leaf);
@@ -34,13 +33,6 @@ export class ContextWorkspacesView extends ItemView {
 	}
 
 	async onOpen(): Promise<void> {
-		// Add a gear button to the view header that opens the plugin settings.
-		// Guarded so reopening the view does not stack duplicate actions.
-		if (!this.settingsActionAdded) {
-			this.addAction('settings', 'Open settings', () => this.plugin.openSettings());
-			this.settingsActionAdded = true;
-		}
-
 		const container = this.containerEl.children[1];
 		if (container.instanceOf(HTMLElement)) {
 			container.empty();

--- a/styles.css
+++ b/styles.css
@@ -450,6 +450,7 @@
 	flex: 1;
 }
 
+.obsidian-context-workspaces-header .obsidian-context-workspaces-settings-btn,
 .obsidian-context-workspaces-header .obsidian-context-workspaces-help-btn,
 .obsidian-context-workspaces-header .obsidian-context-workspaces-add-btn {
 	flex-shrink: 0;
@@ -507,6 +508,29 @@
 }
 
 .obsidian-context-workspaces-help-btn:hover {
+	background: var(--interactive-hover);
+	transform: scale(1.1);
+	color: var(--text-accent);
+}
+
+/* Settings button */
+.obsidian-context-workspaces-settings-btn {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	border: 1px solid var(--background-modifier-border);
+	background: var(--interactive-normal);
+	color: var(--text-normal);
+	cursor: pointer;
+	font-size: 12px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: var(--obsidian-context-workspaces-transition);
+	margin-right: 4px;
+}
+
+.obsidian-context-workspaces-settings-btn:hover {
 	background: var(--interactive-hover);
 	transform: scale(1.1);
 	color: var(--text-accent);


### PR DESCRIPTION
## Problem

The settings gear added in #5 (PR #10) **never appeared** in the sidebar.

## Root cause

It was added with `ItemView.addAction()`, which places the icon in the **view header's action area** (`.view-actions`). That area is rendered for main-area tabs, but **not for left-sidebar `ItemView`s** — so the button was created but invisible. (Core sidebar plugins render their action buttons inside the panel content for this same reason.)

The React sidebar content *does* render (the space list shows), which confirmed `onOpen()` ran and the button element existed — it just lived in a non-rendered header.

## Fix

Move the gear into the sidebar's **own header** (the React `SidebarManager`), right next to the existing view-mode / help / add buttons, where it's always visible — which is also where the issue's screenshot put it. It still calls `openSettings()`. The `addAction` wiring is removed from the view.

- `src/views/ContextWorkspacesView.ts` — drop `addAction` + the guard flag
- `src/components/SidebarManager.tsx` — gear button in the header → `plugin.openSettings()`
- `styles.css` — styling matching the sibling header buttons

## Verification

- ✅ `tsc -noEmit -skipLibCheck`, eslint, 133 tests, production build
- ⚠️ Needs a manual check in Obsidian (UI visibility isn't unit-testable here): open the sidebar → the gear shows in the panel header → clicking it opens this plugin's settings.

Follow-up to #5 (PR #10).