### PR TITLE
fix: default emoji picker locale to English

### DIFF
--- a/src/components/EmojiPicker.tsx
+++ b/src/components/EmojiPicker.tsx
@@ -43,7 +43,7 @@ export const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect, theme =
 			emojiSize: 20,
 			perLine: 8,
 			maxFrequentRows: 0,
-			locale: 'ko',
+			locale: 'en',
 			categories: [
 				'frequent',
 				'people',


### PR DESCRIPTION
## Summary
The emoji picker (`emoji-mart`) had its `locale` hardcoded to `'ko'`, so the search placeholder ("검색") and category labels ("스마일리 및 사람", etc.) rendered in Korean regardless of the user's system language. This switches the default to `'en'`.

## Change
- `src/components/EmojiPicker.tsx`: `locale: 'ko'` → `locale: 'en'`

`'en'` is emoji-mart's own default locale, so it is guaranteed valid.

## Testing
- `pnpm test` — 133 tests pass (incl. `emoji-picker.test.ts`)
- Pre-commit hooks (lint, type-check) pass

## Before / After
- Before: emoji picker shows "검색" / "스마일리 및 사람"
- After: emoji picker shows "Search" / "Smileys & People"